### PR TITLE
gdsfactory-gen: Added fix for overlaps in the straight route via placements

### DIFF
--- a/openfasoc/generators/gdsfactory-gen/pygen/opamp.py
+++ b/openfasoc/generators/gdsfactory-gen/pygen/opamp.py
@@ -1,3 +1,6 @@
+if __name__ == "__main__":
+	import sys
+	sys.path.append("../")
 from gdsfactory.cell import cell, clear_cache
 from gdsfactory.component import Component, copy
 from gdsfactory.components.rectangle import rectangle
@@ -334,7 +337,7 @@ def opamp(
 
 
 if __name__ == "__main__":
-	from . pdk.util.standard_main import pdk
+	from pdk.util.standard_main import pdk
 
 	iterate=False
 # TO TRY:


### PR DESCRIPTION
Via placements in the straight route code led to a few buggy overlaps in layouts. Orientation of the vias is now taken as input from the programmer or is according to the orientation of the port by default. Added relative import fixes for op-amp and straight route standalone testing as well. Tested locally on op-amp gen.